### PR TITLE
Add basic Python medical quiz

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# questionpourunsoignant
+# Medical Quiz Application
+
+This repository provides a simple command-line quiz application for
+medical students or professionals. Questions are stored in a JSON file so
+new questions can easily be added without modifying the source code.
+
+## Requirements
+
+- Python 3.7+
+
+## Usage
+
+1. Install Python if not already available.
+2. Run the quiz:
+
+```bash
+python quiz.py
+```
+
+Answer each question by typing the number of the chosen option.
+A summary of your score will appear at the end of the quiz.
+
+## Adding Questions
+
+Questions are stored in `questions.json`. Each question has a category,
+its text, an array of possible options, and the index of the correct
+answer. Example entry:
+
+```json
+{
+  "category": "Cardiology",
+  "question": "Which organ pumps blood throughout the body?",
+  "options": ["Heart", "Liver", "Lung", "Kidney"],
+  "answer": 0
+}
+```
+
+Add more entries to the JSON array to extend the quiz.
+
+## Future Improvements
+
+This basic application can be expanded with features such as:
+
+- Question difficulty levels.
+- A timer for each question.
+- Review of correct answers after completing the quiz.
+
+Feel free to experiment and enhance the application to suit your needs.

--- a/questions.json
+++ b/questions.json
@@ -1,0 +1,20 @@
+[
+  {
+    "category": "Cardiology",
+    "question": "Which organ pumps blood throughout the body?",
+    "options": ["Heart", "Liver", "Lung", "Kidney"],
+    "answer": 0
+  },
+  {
+    "category": "Pediatrics",
+    "question": "Which of the following is a recommended vaccine for children?",
+    "options": ["BCG", "Beta-blockers", "Insulin", "Amoxicillin"],
+    "answer": 0
+  },
+  {
+    "category": "Internal Medicine",
+    "question": "Type 1 diabetes is characterized by deficiency of which hormone?",
+    "options": ["Insulin", "Cortisol", "Thyroxine", "Estrogen"],
+    "answer": 0
+  }
+]

--- a/quiz.py
+++ b/quiz.py
@@ -1,0 +1,45 @@
+import json
+import random
+from typing import List, Dict
+
+
+def load_questions(filename: str) -> List[Dict]:
+    """Load questions from a JSON file."""
+    with open(filename, 'r', encoding='utf-8') as f:
+        questions = json.load(f)
+    return questions
+
+
+def run_quiz(questions: List[Dict]) -> None:
+    """Run the quiz interactively in the terminal."""
+    random.shuffle(questions)
+    score = 0
+    for idx, q in enumerate(questions, start=1):
+        print(f"\nQuestion {idx} ({q['category']}): {q['question']}")
+        for i, option in enumerate(q['options']):
+            print(f"  {i + 1}. {option}")
+        while True:
+            try:
+                choice = int(input("Your answer (number): ")) - 1
+                if 0 <= choice < len(q['options']):
+                    break
+                else:
+                    print("Please enter a valid option number.")
+            except ValueError:
+                print("Please enter a number.")
+        if choice == q['answer']:
+            print("Correct!\n")
+            score += 1
+        else:
+            correct_option = q['options'][q['answer']]
+            print(f"Incorrect. The correct answer was: {correct_option}\n")
+    print(f"Quiz finished! You scored {score}/{len(questions)}.")
+
+
+def main() -> None:
+    questions = load_questions('questions.json')
+    run_quiz(questions)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add sample questions in JSON format
- implement `quiz.py` to load and run questions interactively
- document usage and future improvements in README

## Testing
- `python quiz.py` *(works interactively)*

------
https://chatgpt.com/codex/tasks/task_e_687966d70e0c832b93fbe2e3c5f8ec36